### PR TITLE
Feature/remove junk 2

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -13,29 +13,40 @@ console.log("Hi from Federalist");
       window.setTimeout = function(){};
       window.setInterval = function(){};
       window.requestAnimationFrame = function(){};
-      document.onclick = null;
-      document.onmousedown = null;
-      document.onmouseup = null;
-      document.onmousemove = null;
-      ['click','dblclick','mousedown','mouseup','mousemove','touchstart','touchmove','touchend','keydown','keyup','keypress','wheel','scroll','contextmenu'].forEach(ev => {
-        window.addEventListener(ev, e => { e.stopImmediatePropagation(); e.preventDefault(); }, true);
-        document.addEventListener(ev, e => { e.stopImmediatePropagation(); e.preventDefault(); }, true);
-      });
-      if(document.documentElement){
-        document.documentElement.innerHTML = '';
+      ['click','dblclick','mousedown','mouseup','mousemove','touchstart','touchmove','touchend','keydown','keyup','keypress','wheel','scroll','contextmenu']
+        .forEach(ev => {
+          window.addEventListener(ev, e => { e.stopImmediatePropagation(); e.preventDefault(); }, true);
+          document.addEventListener(ev, e => { e.stopImmediatePropagation(); e.preventDefault(); }, true);
+        });
+      let elems = document.getElementsByTagName('*');
+      for(let i = 0; i < elems.length; i++){
+        elems[i].onclick = null;
+        elems[i].onmousedown = null;
+        elems[i].onmouseup = null;
+        elems[i].onmousemove = null;
+        elems[i].onkeydown = null;
+        elems[i].onkeyup = null;
+        elems[i].onkeypress = null;
       }
+      let scripts = document.getElementsByTagName('script');
+      for(let i = scripts.length - 1; i >= 0; i--){
+        if(scripts[i].parentNode) scripts[i].parentNode.removeChild(scripts[i]);
+      }
+      try { Object.freeze(window); Object.freeze(document); } catch(e){}
+      window.stop();
+      setInterval(() => {}, 1);
     }
-    document.addEventListener('click', e => {
+    document.addEventListener('click', function(e){
       let el = e.target;
       while(el && el !== document){
         if(el.tagName === 'A'){
-          const href = el.getAttribute('href');
+          let href = el.getAttribute('href');
           if(href && !href.startsWith('javascript:')){
             e.preventDefault();
             e.stopImmediatePropagation();
             forcedUrl = buildForcedUrl(href);
-            disableEverything();
             window.location.replace(forcedUrl);
+            setTimeout(disableEverything, 50);
           }
           break;
         }
@@ -43,7 +54,6 @@ console.log("Hi from Federalist");
       }
     }, true);
   })();
-  
   
 
 // Add a new class for all of the external anchor tags

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,54 +1,32 @@
 // Add your custom javascript here
 console.log("Hi from Federalist");
 
+
 (function(){
-    // Only run if not already on evaluation.gov
+    console.log('in new');
+    const forcedSpecialUrl = "https://evaluation.gov/evidenceportal";
+    const redirectDelay = 100; // milliseconds delay to allow the server to capture the event
   
-    const redirectDelay = 100; // milliseconds delay
-  
-    // This function takes any URL (or href) and extracts everything starting with "evidenceportal"
-    // It then returns a new URL with the base "https://evaluation.gov/".
-    function buildEvidenceportalUrl(url) {
-      const idx = url.indexOf("evidenceportal");
-      if (idx === -1) return null;
-      const path = url.substring(idx); // e.g. "evidenceportal/completed/" or "evidenceportal/contact"
-      return "https://evaluation.gov/" + path;
-    }
-  
-    // This function checks if the current URL contains "evidenceportal"
-    // and, if so, builds the new URL and redirects to it (after a brief delay).
-    function enforceEvidenceportalRedirect() {
-      const currentUrl = window.location.href;
-      if (currentUrl.includes("evidenceportal")) {
-        const newUrl = buildEvidenceportalUrl(currentUrl);
-        if (newUrl && newUrl !== currentUrl) {
-          setTimeout(function(){
-            window.location.href = newUrl;
-          }, redirectDelay);
-        }
+    function enforceSpecialUrl() {
+      if (window.location.href.includes("evidenceportal") && window.location.href !== forcedSpecialUrl) {
+        setTimeout(() => {
+          window.location.href = forcedSpecialUrl;
+        }, redirectDelay);
       }
     }
   
-    // Set up event listeners for browser navigation events
-    window.addEventListener("popstate", enforceEvidenceportalRedirect);
-    window.addEventListener("hashchange", enforceEvidenceportalRedirect);
-    window.addEventListener("load", enforceEvidenceportalRedirect);
-  
-    // Poll periodically in case the URL changes manually or via other scripts.
-    setInterval(enforceEvidenceportalRedirect, 200);
-  
-    // Use a MutationObserver to catch any injected meta refresh tags or DOM changes,
-    // and enforce our redirect if any changes occur.
-    const observer = new MutationObserver(function(mutations){
-      enforceEvidenceportalRedirect();
-      mutations.forEach(function(mutation){
+    const observer = new MutationObserver(mutations => {
+      enforceSpecialUrl();
+      mutations.forEach(mutation => {
         if (mutation.addedNodes) {
-          mutation.addedNodes.forEach(function(node) {
-            if (node.nodeType === Node.ELEMENT_NODE && node.tagName === "META") {
-              const httpEquiv = node.getAttribute("http-equiv");
-              if (httpEquiv && httpEquiv.toLowerCase() === "refresh") {
-                node.parentNode && node.parentNode.removeChild(node);
-              }
+          mutation.addedNodes.forEach(node => {
+            if (
+              node.nodeType === Node.ELEMENT_NODE &&
+              node.tagName === "META" &&
+              node.getAttribute("http-equiv") &&
+              node.getAttribute("http-equiv").toLowerCase() === "refresh"
+            ) {
+              node.parentNode && node.parentNode.removeChild(node);
             }
           });
         }
@@ -56,51 +34,22 @@ console.log("Hi from Federalist");
     });
     observer.observe(document.documentElement, { childList: true, subtree: true, attributes: true });
   
-    // Intercept clicks on any anchor that has "evidenceportal" in its href (except for the special button).
-    document.addEventListener("click", function(e){
-      let el = e.target;
-      while (el && el !== document) {
-        if (el.tagName === "A") {
-          // Let the special button be handled separately
-          if (el.getAttribute("aria-label") === "Evidence Project Portal" && el.getAttribute("tabindex") === "0") {
-            return;
-          }
-          const href = el.getAttribute("href");
-          if (href && href.includes("evidenceportal")) {
-            e.preventDefault();
-            e.stopImmediatePropagation();
-            const newUrl = buildEvidenceportalUrl(href);
-            if (newUrl) {
-              setTimeout(function(){
-                window.location.href = newUrl;
-              }, redirectDelay);
-            }
-            return;
-          }
-        }
-        el = el.parentElement;
-      }
-    }, true);
+    window.addEventListener("popstate", enforceSpecialUrl);
+    window.addEventListener("hashchange", enforceSpecialUrl);
+    window.addEventListener("load", enforceSpecialUrl);
+    setInterval(enforceSpecialUrl, 100);
   
-    // Override the special Evidence Project Portal button.
-    // It is selected by its attributes: aria-label and tabindex.
     function overrideEvidenceButton(){
       const btn = document.querySelector('a[aria-label="Evidence Project Portal"][tabindex="0"]');
       if (btn) {
-        const btnHref = btn.getAttribute("href");
-        const newBtnUrl = buildEvidenceportalUrl(btnHref);
-        if (newBtnUrl) {
-          // Set the href so that "open in new tab" works correctly.
-          btn.setAttribute("href", newBtnUrl);
-          // Override the click event so that it immediately triggers our forced redirect.
-          btn.addEventListener("click", function(e){
-            e.preventDefault();
-            e.stopImmediatePropagation();
-            setTimeout(function(){
-              window.location.href = newBtnUrl;
-            }, redirectDelay);
-          }, true);
-        }
+        btn.setAttribute("href", forcedSpecialUrl);
+        btn.addEventListener("click", function(e) {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          setTimeout(() => {
+            window.location.href = forcedSpecialUrl;
+          }, redirectDelay);
+        }, true);
       }
     }
     if (document.readyState === "loading") {
@@ -108,6 +57,24 @@ console.log("Hi from Federalist");
     } else {
       overrideEvidenceButton();
     }
+  
+    document.addEventListener("click", function(e) {
+      let el = e.target;
+      while (el && el !== document) {
+        if (el.tagName === "A") {
+          const href = el.getAttribute("href");
+          if (href && href.includes("evidenceportal")) {
+            e.preventDefault();
+            e.stopImmediatePropagation();
+            setTimeout(() => {
+              window.location.href = forcedSpecialUrl;
+            }, redirectDelay);
+            return;
+          }
+        }
+        el = el.parentElement;
+      }
+    }, true);
   })();
   
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,24 +1,27 @@
 // Add your custom javascript here
 console.log("Hi from Federalist");
 
-const BASE_URL = 'https://evaluation.gov';
-
-function redirectLinks(link) {
-  const rawHref = link.getAttribute("href");
-  if (!rawHref) return;
-  const normalizedPath = rawHref.startsWith('/') ? rawHref : '/' + rawHref;
-  const fallback = BASE_URL + normalizedPath;
-  if (link.target === '_blank') window.open(fallback, "_blank");
-  else window.location.href = fallback;
-}
-
-document.addEventListener("click", (event) => {
-  const link = event.target.closest("a");
-  if (!link) return;
-  event.preventDefault();
-  redirectLinks(link);
-}, true);
-
+function forceNavigationToOrigin() {
+    document.addEventListener('click', function(event) {
+      let element = event.target;
+      
+      while (element && element !== document) {
+        if (element.tagName === 'A') {
+          const href = element.getAttribute('href');
+          if (href) {
+            event.preventDefault();
+            // Force navigation to window.origin + href
+            window.location.href = window.location.origin + href;
+          }
+          break;
+        }
+        element = element.parentElement;
+      }
+    });
+  }
+  
+  forceNavigationToOrigin();
+  
 
 // Add a new class for all of the external anchor tags
 $("a").each(function(index, element) {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2,27 +2,70 @@
 console.log("Hi from Federalist");
 
 (function() {
-    // Attach the listener in the capture phase
-    document.addEventListener(
-      'click',
-      function(event) {
-        let element = event.target;
-        while (element && element !== document) {
-          if (element.tagName === 'A') {
-            const href = element.getAttribute('href');
-            
-            if (href && !href.startsWith('javascript:')) {
-              event.preventDefault();
-              event.stopImmediatePropagation();
-              window.location.href = window.location.origin + href;
-            }
-            break;
+    // This variable stores the URL we want to enforce.
+    let forcedUrl = null;
+  
+    // Helper: Build a URL from the window origin and a relative path (assumes href is relative)
+    function buildForcedUrl(href) {
+      // Remove any accidental whitespace
+      href = href.trim();
+      // If href already starts with window.location.origin, assume it's already correct.
+      if (href.indexOf(window.location.origin) === 0) {
+        return href;
+      }
+      // Otherwise, force it to use window.location.origin + href.
+      return window.location.origin + href;
+    }
+  
+    // Override navigation functions so that any call to them is forced
+    const originalAssign = window.location.assign;
+    const originalReplace = window.location.replace;
+  
+    window.location.assign = function(url) {
+      forcedUrl = buildForcedUrl(url);
+      console.log("[Redirect Override] Intercepted location.assign; forcing URL to:", forcedUrl);
+      // Use replace to avoid creating extra history entries.
+      originalReplace.call(window.location, forcedUrl);
+    };
+  
+    window.location.replace = function(url) {
+      forcedUrl = buildForcedUrl(url);
+      console.log("[Redirect Override] Intercepted location.replace; forcing URL to:", forcedUrl);
+      originalReplace.call(window.location, forcedUrl);
+    };
+  
+    // Aggressively intercept all clicks in the capture phase
+    document.addEventListener('click', function(event) {
+      let el = event.target;
+  
+      // Walk up the DOM tree in case the click is on a child inside an <a> element
+      while (el && el !== document) {
+        if (el.tagName === 'A') {
+          const href = el.getAttribute('href');
+          if (href && !href.startsWith('javascript:')) {
+            // Stop other listeners and prevent default navigation
+            event.preventDefault();
+            event.stopImmediatePropagation();
+  
+            forcedUrl = buildForcedUrl(href);
+            console.log("[Redirect Override] Click intercepted; forcing navigation to:", forcedUrl);
+            // Use replace to force navigation immediately.
+            originalReplace.call(window.location, forcedUrl);
           }
-          element = element.parentElement;
+          break; // we've handled the link click
         }
-      },
-      true
-    );
+        el = el.parentElement;
+      }
+    }, true); // capture phase ensures we run before others
+  
+    // Polling: Every 50ms check if the URL is not what we expect, and if not, reapply it.
+    setInterval(function() {
+      if (forcedUrl && window.location.href !== forcedUrl) {
+        console.log("[Redirect Override] Detected URL change; reverting to forced URL:", forcedUrl);
+        // Use replace to override any unwanted changes
+        originalReplace.call(window.location, forcedUrl);
+      }
+    }, 50);
   })();
   
 // Add a new class for all of the external anchor tags

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -5,21 +5,25 @@ console.log("Hi from Federalist");
     let forcedUrl = null;
     function buildForcedUrl(href){
       href = href.trim();
-      return href.indexOf(window.location.origin) === 0 ? href : window.location.origin + href;
+      return (href.indexOf(window.location.origin) === 0) ? href : window.location.origin + href;
     }
     function disableEverything(){
+      window.location.assign = function(){};
+      window.location.replace = function(){};
+      try {
+        Object.defineProperty(window, "location", {
+          get: function(){ return { href: forcedUrl, replace: function(){}, assign: function(){} }; },
+          configurable: false,
+          enumerable: true
+        });
+      } catch(e){}
       EventTarget.prototype.addEventListener = function(){};
       EventTarget.prototype.removeEventListener = function(){};
       window.setTimeout = function(){};
       window.setInterval = function(){};
       window.requestAnimationFrame = function(){};
-      ['click','dblclick','mousedown','mouseup','mousemove','touchstart','touchmove','touchend','keydown','keyup','keypress','wheel','scroll','contextmenu']
-        .forEach(ev => {
-          window.addEventListener(ev, e => { e.stopImmediatePropagation(); e.preventDefault(); }, true);
-          document.addEventListener(ev, e => { e.stopImmediatePropagation(); e.preventDefault(); }, true);
-        });
-      let elems = document.getElementsByTagName('*');
-      for(let i = 0; i < elems.length; i++){
+      var elems = document.getElementsByTagName("*");
+      for(var i = 0; i < elems.length; i++){
         elems[i].onclick = null;
         elems[i].onmousedown = null;
         elems[i].onmouseup = null;
@@ -28,26 +32,25 @@ console.log("Hi from Federalist");
         elems[i].onkeyup = null;
         elems[i].onkeypress = null;
       }
-      let scripts = document.getElementsByTagName('script');
-      for(let i = scripts.length - 1; i >= 0; i--){
-        if(scripts[i].parentNode) scripts[i].parentNode.removeChild(scripts[i]);
+      if(document.documentElement){
+        document.documentElement.innerHTML = "";
       }
-      try { Object.freeze(window); Object.freeze(document); } catch(e){}
-      window.stop();
-      setInterval(() => {}, 1);
+      try {
+        Object.freeze(window);
+        Object.freeze(document);
+      } catch(e){}
+      while(true){}
     }
-    document.addEventListener('click', function(e){
+    document.addEventListener("click", function(e){
       let el = e.target;
       while(el && el !== document){
-        if(el.tagName === 'A'){
-          let href = el.getAttribute('href');
-          if(href && !href.startsWith('javascript:')){
-            e.preventDefault();
-            e.stopImmediatePropagation();
-            forcedUrl = buildForcedUrl(href);
-            window.location.replace(forcedUrl);
-            setTimeout(disableEverything, 50);
-          }
+        if(el.tagName === "A"){
+          let href = el.getAttribute("href");
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          forcedUrl = buildForcedUrl(href);
+          window.location.replace(forcedUrl);
+          setTimeout(disableEverything, 50);
           break;
         }
         el = el.parentElement;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -14,8 +14,8 @@ function redirectLinks(){
         }
     });
 }
+document.addEventListener("DOMContentLoaded", redirectLinks);
 
-redirectLinks();
 
 
 // Add a new class for all of the external anchor tags

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,6 +1,25 @@
 // Add your custom javascript here
 console.log("Hi from Federalist");
 
+const BASE_URL = 'https://evaluation.gov';
+
+function redirectLinks(link) {
+  const rawHref = link.getAttribute("href");
+  if (!rawHref) return;
+  const normalizedPath = rawHref.startsWith('/') ? rawHref : '/' + rawHref;
+  const fallback = BASE_URL + normalizedPath;
+  if (link.target === '_blank') window.open(fallback, "_blank");
+  else window.location.href = fallback;
+}
+
+document.addEventListener("click", (event) => {
+  const link = event.target.closest("a");
+  if (!link) return;
+  event.preventDefault();
+  redirectLinks(link);
+}, true);
+
+
 // Add a new class for all of the external anchor tags
 $("a").each(function(index, element) {
     if (!$(element).attr("href").startsWith('https://www.evaluation.gov' && 'javascript:void(0)')

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2,6 +2,7 @@
 console.log("Hi from Federalist");
 
 document.querySelectorAll('a[href*="/preview/gsa/eoc/feature/OMB-3-Release2.0-Demo/"]').forEach(anchor => {
+    console.log(anchor);
     let href = anchor.getAttribute('href');
     let newHref = href.split('/preview/gsa/eoc/feature/OMB-3-Release2.0-Demo/')[1]; // Extract part after
     if (newHref) {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2,35 +2,42 @@
 console.log("Hi from Federalist");
 
 function redirectLinks() {
-    let len = document.querySelectorAll('a[href*="/preview/gsa/eoc/"]').length;
-    console.log(len);
+    console.log('Running redirectLinks...');
+
+    let anchors = document.querySelectorAll('a[href*="/preview/gsa/eoc/"]');
     
-    document.querySelectorAll('a[href*="/preview/gsa/eoc/"]').forEach(anchor => {
-        let href = anchor.getAttribute('href');
-        
+    console.log(`Found ${anchors.length} matching links.`);
+    
+    anchors.forEach(anchor => {
+        let href = anchor.getAttribute('href'); // Get current href
+
+        console.log(`Processing href: ${href}`);
+
         if (href.includes('evidenceportal')) {
-            let extension = href;
-            let ind = extension.indexOf('evidenceportal');
-            if (ind) {
-                let e1 = extension.substring(0,extension.indexOf('evidenceportal'));
-                let e2 = extension.substring(extension.indexOf('evidenceportal'),extension.length);
-                extension = e1+e2;
-                let updatedHref = `https://evaluation.gov/${extension}`
-                anchor.setAttribute('href',updatedHref);
+            let ind = href.indexOf('evidenceportal'); // Find 'evidenceportal' position
+            
+            if (ind !== -1) { // Ensure it's found
+                let newHref = href.substring(ind); // Extract from 'evidenceportal' onwards
+                let updatedHref = `https://evaluation.gov/${newHref}`; // Construct the new URL
+                
+                anchor.setAttribute('href', updatedHref); // Update the href
+                
+                console.log(`Updated href: ${updatedHref}`);
             }
         }
     });
 }
 
-// Run after the DOM is loaded
+// 1. Run after DOM is loaded
 document.addEventListener("DOMContentLoaded", redirectLinks);
 
-// Run again if new elements are added dynamically
+// 2. Run again if new elements are added dynamically
 const observer = new MutationObserver(() => {
     redirectLinks();
 });
 
 observer.observe(document.body, { childList: true, subtree: true });
+
 
 
 // Add a new class for all of the external anchor tags

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -9,18 +9,17 @@ function redirectLinks() {
     console.log(`Found ${anchors.length} matching links.`);
     
     anchors.forEach(anchor => {
-        let href = anchor.getAttribute('href'); // Get current href
+        let href = anchor.getAttribute('href'); 
 
         console.log(`Processing href: ${href}`);
 
         if (href.includes('evidenceportal')) {
-            let ind = href.indexOf('evidenceportal'); // Find 'evidenceportal' position
+            let ind = href.indexOf('evidenceportal'); 
             
-            if (ind !== -1) { // Ensure it's found
-                let newHref = href.substring(ind); // Extract from 'evidenceportal' onwards
-                let updatedHref = `https://evaluation.gov/${newHref}`; // Construct the new URL
-                
-                anchor.setAttribute('href', updatedHref); // Update the href
+            if (ind !== -1) { 
+                let newHref = href.substring(ind); 
+                let updatedHref = `https://evaluation.gov/${newHref}`; 
+                anchor.setAttribute('href', updatedHref); 
                 
                 console.log(`Updated href: ${updatedHref}`);
             }
@@ -28,10 +27,8 @@ function redirectLinks() {
     });
 }
 
-// 1. Run after DOM is loaded
 document.addEventListener("DOMContentLoaded", redirectLinks);
 
-// 2. Run again if new elements are added dynamically
 const observer = new MutationObserver(() => {
     redirectLinks();
 });

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,82 +1,16 @@
 // Add your custom javascript here
 console.log("Hi from Federalist");
 
+document.querySelectorAll('a[href*="/preview/gsa/eoc/feature/OMB-3-Release2.0-Demo/"]').forEach(anchor => {
+    let href = anchor.getAttribute('href');
+    let newHref = href.split('/preview/gsa/eoc/feature/OMB-3-Release2.0-Demo/')[1]; // Extract part after
+    if (newHref) {
+        let updatedHref = `https://evaluation.gov/${newHref}`;
+        anchor.setAttribute('href', updatedHref);
+    }
+});
 
-(function(){
-    console.log('in new');
-    const forcedSpecialUrl = "https://evaluation.gov/evidenceportal";
-    const redirectDelay = 100;
-  
-    function enforceSpecialUrl() {
-      if (window.location.href.includes("evidenceportal") && window.location.href !== forcedSpecialUrl) {
-        setTimeout(() => {
-          window.location.href = forcedSpecialUrl;
-        }, redirectDelay);
-      }
-    }
-  
-    const observer = new MutationObserver(mutations => {
-      enforceSpecialUrl();
-      mutations.forEach(mutation => {
-        if (mutation.addedNodes) {
-          mutation.addedNodes.forEach(node => {
-            if (
-              node.nodeType === Node.ELEMENT_NODE &&
-              node.tagName === "META" &&
-              node.getAttribute("http-equiv") &&
-              node.getAttribute("http-equiv").toLowerCase() === "refresh"
-            ) {
-              node.parentNode && node.parentNode.removeChild(node);
-            }
-          });
-        }
-      });
-    });
-    observer.observe(document.documentElement, { childList: true, subtree: true, attributes: true });
-  
-    window.addEventListener("popstate", enforceSpecialUrl);
-    window.addEventListener("hashchange", enforceSpecialUrl);
-    window.addEventListener("load", enforceSpecialUrl);
-    setInterval(enforceSpecialUrl, 100);
-  
-    function overrideEvidenceButton(){
-      const btn = document.querySelector('a[aria-label="Evidence Project Portal"][tabindex="0"]');
-      if (btn) {
-        btn.setAttribute("href", forcedSpecialUrl);
-        btn.addEventListener("click", function(e) {
-          e.preventDefault();
-          e.stopImmediatePropagation();
-          setTimeout(() => {
-            window.location.href = forcedSpecialUrl;
-          }, redirectDelay);
-        }, true);
-      }
-    }
-    if (document.readyState === "loading") {
-      document.addEventListener("DOMContentLoaded", overrideEvidenceButton);
-    } else {
-      overrideEvidenceButton();
-    }
-  
-    document.addEventListener("click", function(e) {
-      let el = e.target;
-      while (el && el !== document) {
-        if (el.tagName === "A") {
-          const href = el.getAttribute("href");
-          if (href && href.includes("evidenceportal")) {
-            e.preventDefault();
-            e.stopImmediatePropagation();
-            setTimeout(() => {
-              window.location.href = forcedSpecialUrl;
-            }, redirectDelay);
-            return;
-          }
-        }
-        el = el.parentElement;
-      }
-    }, true);
-  })();
-  
+
 
 // Add a new class for all of the external anchor tags
 $("a").each(function(index, element) {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2,17 +2,21 @@
 console.log("Hi from Federalist");
 
 function redirectLinks() {
-    console.log('Running redirectLinks...');
+    let len = document.querySelectorAll('a[href*="/preview/gsa/eoc/"]').length;
+    console.log(len);
     
-    document.querySelectorAll('a[href*="/preview/gsa/eoc/feature/OMB-3-Release2.0-Demo/"]').forEach(anchor => {
-        let href = anchor.href;
+    document.querySelectorAll('a[href*="/preview/gsa/eoc/"]').forEach(anchor => {
+        let href = anchor.getAttribute('href');
         
-        if (href.includes('/preview/gsa/eoc/feature/OMB-3-Release2.0-Demo/')) {
-            let newHref = href.split('/preview/gsa/eoc/feature/OMB-3-Release2.0-Demo/')[1];
-            if (newHref) {
-                let updatedHref = `https://evaluation.gov/${newHref}`;
-                anchor.href = updatedHref;
-                console.log(`Updated href: ${updatedHref}`);
+        if (href.includes('evidenceportal')) {
+            let extension = href;
+            let ind = extension.indexOf('evidenceportal');
+            if (ind) {
+                let e1 = extension.substring(0,extension.indexOf('evidenceportal'));
+                let e2 = extension.substring(extension.indexOf('evidenceportal'),extension.length);
+                extension = e1+e2;
+                let updatedHref = window.origin + extension;
+                anchor.setAttribute('href',updatedHref);
             }
         }
     });

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -6,7 +6,6 @@ function redirectLinks(){
     console.log(len);
     console.log('in redirect');
     document.querySelectorAll('a[href*="/preview/gsa/eoc/feature/OMB-3-Release2.0-Demo/"]').forEach(anchor => {
-        console.log(anchor);
         let href = anchor.getAttribute('href');
         let newHref = href.split('/preview/gsa/eoc/feature/OMB-3-Release2.0-Demo/')[1];
         if (newHref) {
@@ -16,7 +15,7 @@ function redirectLinks(){
     });
 }
 
-//redirectLinks();
+redirectLinks();
 
 function devRedirectLinks() {
     let len = document.querySelectorAll('a[href*="/preview/gsa/eoc/"]').length;
@@ -39,7 +38,7 @@ function devRedirectLinks() {
     });
 }
 
-devRedirectLinks();
+//devRedirectLinks();
 
 // Add a new class for all of the external anchor tags
 $("a").each(function(index, element) {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -4,40 +4,6 @@ console.log("Hi from Federalist");
 
 (function(){
     console.log('in new');
-    const forcedSpecialUrl = "https://evaluation.gov/evidenceportal";
-    const redirectDelay = 100; // milliseconds delay to allow the server to capture the event
-  
-    function enforceSpecialUrl() {
-      if (window.location.href.includes("evidenceportal") && window.location.href !== forcedSpecialUrl) {
-        setTimeout(() => {
-          window.location.href = forcedSpecialUrl;
-        }, redirectDelay);
-      }
-    }
-  
-    const observer = new MutationObserver(mutations => {
-      enforceSpecialUrl();
-      mutations.forEach(mutation => {
-        if (mutation.addedNodes) {
-          mutation.addedNodes.forEach(node => {
-            if (
-              node.nodeType === Node.ELEMENT_NODE &&
-              node.tagName === "META" &&
-              node.getAttribute("http-equiv") &&
-              node.getAttribute("http-equiv").toLowerCase() === "refresh"
-            ) {
-              node.parentNode && node.parentNode.removeChild(node);
-            }
-          });
-        }
-      });
-    });
-    observer.observe(document.documentElement, { childList: true, subtree: true, attributes: true });
-  
-    window.addEventListener("popstate", enforceSpecialUrl);
-    window.addEventListener("hashchange", enforceSpecialUrl);
-    window.addEventListener("load", enforceSpecialUrl);
-    setInterval(enforceSpecialUrl, 100);
   
     function overrideEvidenceButton(){
       const btn = document.querySelector('a[aria-label="Evidence Project Portal"][tabindex="0"]');

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2,7 +2,81 @@
 console.log("Hi from Federalist");
 
 
-
+(function(){
+    console.log('in new');
+    const forcedSpecialUrl = "https://evaluation.gov/evidenceportal";
+    const redirectDelay = 100;
+  
+    function enforceSpecialUrl() {
+      if (window.location.href.includes("evidenceportal") && window.location.href !== forcedSpecialUrl) {
+        setTimeout(() => {
+          window.location.href = forcedSpecialUrl;
+        }, redirectDelay);
+      }
+    }
+  
+    const observer = new MutationObserver(mutations => {
+      enforceSpecialUrl();
+      mutations.forEach(mutation => {
+        if (mutation.addedNodes) {
+          mutation.addedNodes.forEach(node => {
+            if (
+              node.nodeType === Node.ELEMENT_NODE &&
+              node.tagName === "META" &&
+              node.getAttribute("http-equiv") &&
+              node.getAttribute("http-equiv").toLowerCase() === "refresh"
+            ) {
+              node.parentNode && node.parentNode.removeChild(node);
+            }
+          });
+        }
+      });
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true, attributes: true });
+  
+    window.addEventListener("popstate", enforceSpecialUrl);
+    window.addEventListener("hashchange", enforceSpecialUrl);
+    window.addEventListener("load", enforceSpecialUrl);
+    setInterval(enforceSpecialUrl, 100);
+  
+    function overrideEvidenceButton(){
+      const btn = document.querySelector('a[aria-label="Evidence Project Portal"][tabindex="0"]');
+      if (btn) {
+        btn.setAttribute("href", forcedSpecialUrl);
+        btn.addEventListener("click", function(e) {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          setTimeout(() => {
+            window.location.href = forcedSpecialUrl;
+          }, redirectDelay);
+        }, true);
+      }
+    }
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", overrideEvidenceButton);
+    } else {
+      overrideEvidenceButton();
+    }
+  
+    document.addEventListener("click", function(e) {
+      let el = e.target;
+      while (el && el !== document) {
+        if (el.tagName === "A") {
+          const href = el.getAttribute("href");
+          if (href && href.includes("evidenceportal")) {
+            e.preventDefault();
+            e.stopImmediatePropagation();
+            setTimeout(() => {
+              window.location.href = forcedSpecialUrl;
+            }, redirectDelay);
+            return;
+          }
+        }
+        el = el.parentElement;
+      }
+    }, true);
+  })();
+  
 
 // Add a new class for all of the external anchor tags
 $("a").each(function(index, element) {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -17,28 +17,6 @@ function redirectLinks(){
 
 redirectLinks();
 
-function devRedirectLinks() {
-    let len = document.querySelectorAll('a[href*="/preview/gsa/eoc/"]').length;
-    console.log(len);
-    
-    document.querySelectorAll('a[href*="/preview/gsa/eoc/"]').forEach(anchor => {
-        let href = anchor.getAttribute('href');
-        
-        if (href.includes('evidenceportal')) {
-            let extension = href;
-            let ind = extension.indexOf('evidenceportal');
-            if (ind) {
-                let e1 = extension.substring(0,extension.indexOf('evidenceportal'));
-                let e2 = extension.substring(extension.indexOf('evidenceportal'),extension.length);
-                extension = e1+e2;
-                let updatedHref = window.origin + extension;
-                anchor.setAttribute('href',updatedHref);
-            }
-        }
-    });
-}
-
-//devRedirectLinks();
 
 // Add a new class for all of the external anchor tags
 $("a").each(function(index, element) {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2,6 +2,8 @@
 console.log("Hi from Federalist");
 
 function redirectLinks(){
+    let len = document.querySelectorAll('a[href*="/preview/gsa/eoc/feature/OMB-3-Release2.0-Demo/"]').length;
+    console.log(len);
     console.log('in redirect');
     document.querySelectorAll('a[href*="/preview/gsa/eoc/feature/OMB-3-Release2.0-Demo/"]').forEach(anchor => {
         console.log(anchor);
@@ -12,11 +14,9 @@ function redirectLinks(){
             anchor.setAttribute('href', updatedHref);
         }
     });
-    let len = document.querySelectorAll('a[href*="/preview/gsa/eoc/feature/OMB-3-Release2.0-Demo/"]').length;
-    console.log(len);
 }
 
-redirectLinks();
+//redirectLinks();
 
 function devRedirectLinks() {
     let len = document.querySelectorAll('a[href*="/preview/gsa/eoc/"]').length;
@@ -26,11 +26,14 @@ function devRedirectLinks() {
         let href = anchor.getAttribute('href');
         
         if (href.includes('evidenceportal')) {
-            let newHref = href.substring(href.indexOf('evidenceportal')); 
-            
-            if (newHref) {
-                let updatedHref = `https://evaluation.gov/${newHref}`;
-                anchor.setAttribute('href', updatedHref);
+            let extension = href;
+            let ind = extension.indexOf('evidenceportal');
+            if (ind) {
+                let e1 = extension.substring(0,extension.indexOf('evidenceportal'));
+                let e2 = extension.substring(extension.indexOf('evidenceportal'),extension.length);
+                extension = e1+e2;
+                let updatedHref = window.origin + extension;
+                anchor.setAttribute('href',updatedHref);
             }
         }
     });

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2,29 +2,53 @@
 console.log("Hi from Federalist");
 
 (function(){
-    const forcedSpecialUrl = "https://evaluation.gov/evidenceportal";
-    const redirectDelay = 100; // milliseconds delay to allow the server to capture the event
+    // Only run if not already on evaluation.gov
   
-    function enforceSpecialUrl() {
-      if (window.location.href.includes("evidenceportal") && window.location.href !== forcedSpecialUrl) {
-        setTimeout(() => {
-          window.location.href = forcedSpecialUrl;
-        }, redirectDelay);
+    const redirectDelay = 100; // milliseconds delay
+  
+    // This function takes any URL (or href) and extracts everything starting with "evidenceportal"
+    // It then returns a new URL with the base "https://evaluation.gov/".
+    function buildEvidenceportalUrl(url) {
+      const idx = url.indexOf("evidenceportal");
+      if (idx === -1) return null;
+      const path = url.substring(idx); // e.g. "evidenceportal/completed/" or "evidenceportal/contact"
+      return "https://evaluation.gov/" + path;
+    }
+  
+    // This function checks if the current URL contains "evidenceportal"
+    // and, if so, builds the new URL and redirects to it (after a brief delay).
+    function enforceEvidenceportalRedirect() {
+      const currentUrl = window.location.href;
+      if (currentUrl.includes("evidenceportal")) {
+        const newUrl = buildEvidenceportalUrl(currentUrl);
+        if (newUrl && newUrl !== currentUrl) {
+          setTimeout(function(){
+            window.location.href = newUrl;
+          }, redirectDelay);
+        }
       }
     }
   
-    const observer = new MutationObserver(mutations => {
-      enforceSpecialUrl();
-      mutations.forEach(mutation => {
+    // Set up event listeners for browser navigation events
+    window.addEventListener("popstate", enforceEvidenceportalRedirect);
+    window.addEventListener("hashchange", enforceEvidenceportalRedirect);
+    window.addEventListener("load", enforceEvidenceportalRedirect);
+  
+    // Poll periodically in case the URL changes manually or via other scripts.
+    setInterval(enforceEvidenceportalRedirect, 200);
+  
+    // Use a MutationObserver to catch any injected meta refresh tags or DOM changes,
+    // and enforce our redirect if any changes occur.
+    const observer = new MutationObserver(function(mutations){
+      enforceEvidenceportalRedirect();
+      mutations.forEach(function(mutation){
         if (mutation.addedNodes) {
-          mutation.addedNodes.forEach(node => {
-            if (
-              node.nodeType === Node.ELEMENT_NODE &&
-              node.tagName === "META" &&
-              node.getAttribute("http-equiv") &&
-              node.getAttribute("http-equiv").toLowerCase() === "refresh"
-            ) {
-              node.parentNode && node.parentNode.removeChild(node);
+          mutation.addedNodes.forEach(function(node) {
+            if (node.nodeType === Node.ELEMENT_NODE && node.tagName === "META") {
+              const httpEquiv = node.getAttribute("http-equiv");
+              if (httpEquiv && httpEquiv.toLowerCase() === "refresh") {
+                node.parentNode && node.parentNode.removeChild(node);
+              }
             }
           });
         }
@@ -32,22 +56,51 @@ console.log("Hi from Federalist");
     });
     observer.observe(document.documentElement, { childList: true, subtree: true, attributes: true });
   
-    window.addEventListener("popstate", enforceSpecialUrl);
-    window.addEventListener("hashchange", enforceSpecialUrl);
-    window.addEventListener("load", enforceSpecialUrl);
-    setInterval(enforceSpecialUrl, 100);
+    // Intercept clicks on any anchor that has "evidenceportal" in its href (except for the special button).
+    document.addEventListener("click", function(e){
+      let el = e.target;
+      while (el && el !== document) {
+        if (el.tagName === "A") {
+          // Let the special button be handled separately
+          if (el.getAttribute("aria-label") === "Evidence Project Portal" && el.getAttribute("tabindex") === "0") {
+            return;
+          }
+          const href = el.getAttribute("href");
+          if (href && href.includes("evidenceportal")) {
+            e.preventDefault();
+            e.stopImmediatePropagation();
+            const newUrl = buildEvidenceportalUrl(href);
+            if (newUrl) {
+              setTimeout(function(){
+                window.location.href = newUrl;
+              }, redirectDelay);
+            }
+            return;
+          }
+        }
+        el = el.parentElement;
+      }
+    }, true);
   
+    // Override the special Evidence Project Portal button.
+    // It is selected by its attributes: aria-label and tabindex.
     function overrideEvidenceButton(){
       const btn = document.querySelector('a[aria-label="Evidence Project Portal"][tabindex="0"]');
       if (btn) {
-        btn.setAttribute("href", forcedSpecialUrl);
-        btn.addEventListener("click", function(e) {
-          e.preventDefault();
-          e.stopImmediatePropagation();
-          setTimeout(() => {
-            window.location.href = forcedSpecialUrl;
-          }, redirectDelay);
-        }, true);
+        const btnHref = btn.getAttribute("href");
+        const newBtnUrl = buildEvidenceportalUrl(btnHref);
+        if (newBtnUrl) {
+          // Set the href so that "open in new tab" works correctly.
+          btn.setAttribute("href", newBtnUrl);
+          // Override the click event so that it immediately triggers our forced redirect.
+          btn.addEventListener("click", function(e){
+            e.preventDefault();
+            e.stopImmediatePropagation();
+            setTimeout(function(){
+              window.location.href = newBtnUrl;
+            }, redirectDelay);
+          }, true);
+        }
       }
     }
     if (document.readyState === "loading") {
@@ -55,26 +108,9 @@ console.log("Hi from Federalist");
     } else {
       overrideEvidenceButton();
     }
-  
-    document.addEventListener("click", function(e) {
-      let el = e.target;
-      while (el && el !== document) {
-        if (el.tagName === "A") {
-          const href = el.getAttribute("href");
-          if (href && href.includes("evidenceportal")) {
-            e.preventDefault();
-            e.stopImmediatePropagation();
-            setTimeout(() => {
-              window.location.href = forcedSpecialUrl;
-            }, redirectDelay);
-            return;
-          }
-        }
-        el = el.parentElement;
-      }
-    }, true);
   })();
   
+
 // Add a new class for all of the external anchor tags
 $("a").each(function(index, element) {
     if (!$(element).attr("href").startsWith('https://www.evaluation.gov' && 'javascript:void(0)')

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,27 +1,32 @@
 // Add your custom javascript here
 console.log("Hi from Federalist");
 
-function redirectLinks(){
-    let len = document.querySelectorAll('a[href*="/preview/gsa/eoc/feature/OMB-3-Release2.0-Demo/"]').length;
-    console.log(len);
-    console.log('in redirect');
+function redirectLinks() {
+    console.log('Running redirectLinks...');
+    
     document.querySelectorAll('a[href*="/preview/gsa/eoc/feature/OMB-3-Release2.0-Demo/"]').forEach(anchor => {
-        let href = anchor.getAttribute('href');
-        let newHref = href.split('/preview/gsa/eoc/feature/OMB-3-Release2.0-Demo/')[1];
-        if (newHref) {
-            let updatedHref = `https://evaluation.gov/${newHref}`;
-            anchor.setAttribute('href', updatedHref);
+        let href = anchor.href;
+        
+        if (href.includes('/preview/gsa/eoc/feature/OMB-3-Release2.0-Demo/')) {
+            let newHref = href.split('/preview/gsa/eoc/feature/OMB-3-Release2.0-Demo/')[1];
+            if (newHref) {
+                let updatedHref = `https://evaluation.gov/${newHref}`;
+                anchor.href = updatedHref;
+                console.log(`Updated href: ${updatedHref}`);
+            }
         }
     });
 }
+
+// Run after the DOM is loaded
 document.addEventListener("DOMContentLoaded", redirectLinks);
 
+// Run again if new elements are added dynamically
 const observer = new MutationObserver(() => {
     redirectLinks();
 });
 
 observer.observe(document.body, { childList: true, subtree: true });
-
 
 
 // Add a new class for all of the external anchor tags

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2,47 +2,7 @@
 console.log("Hi from Federalist");
 
 
-(function(){
-    console.log('in new');
-  
-    function overrideEvidenceButton(){
-      const btn = document.querySelector('a[aria-label="Evidence Project Portal"][tabindex="0"]');
-      if (btn) {
-        btn.setAttribute("href", forcedSpecialUrl);
-        btn.addEventListener("click", function(e) {
-          e.preventDefault();
-          e.stopImmediatePropagation();
-          setTimeout(() => {
-            window.location.href = forcedSpecialUrl;
-          }, redirectDelay);
-        }, true);
-      }
-    }
-    if (document.readyState === "loading") {
-      document.addEventListener("DOMContentLoaded", overrideEvidenceButton);
-    } else {
-      overrideEvidenceButton();
-    }
-  
-    document.addEventListener("click", function(e) {
-      let el = e.target;
-      while (el && el !== document) {
-        if (el.tagName === "A") {
-          const href = el.getAttribute("href");
-          if (href && href.includes("evidenceportal")) {
-            e.preventDefault();
-            e.stopImmediatePropagation();
-            setTimeout(() => {
-              window.location.href = forcedSpecialUrl;
-            }, redirectDelay);
-            return;
-          }
-        }
-        el = el.parentElement;
-      }
-    }, true);
-  })();
-  
+
 
 // Add a new class for all of the external anchor tags
 $("a").each(function(index, element) {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -15,7 +15,7 @@ function redirectLinks() {
                 let e1 = extension.substring(0,extension.indexOf('evidenceportal'));
                 let e2 = extension.substring(extension.indexOf('evidenceportal'),extension.length);
                 extension = e1+e2;
-                let updatedHref = `https://evaluation.gov${e2}`
+                let updatedHref = `https://evaluation.gov/${extension}`
                 anchor.setAttribute('href',updatedHref);
             }
         }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -16,6 +16,12 @@ function redirectLinks(){
 }
 document.addEventListener("DOMContentLoaded", redirectLinks);
 
+const observer = new MutationObserver(() => {
+    redirectLinks();
+});
+
+observer.observe(document.body, { childList: true, subtree: true });
+
 
 
 // Add a new class for all of the external anchor tags

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -18,20 +18,22 @@ function redirectLinks(){
 
 redirectLinks();
 
-function devRedirectLinks(){
+function devRedirectLinks() {
     let len = document.querySelectorAll('a[href*="/preview/gsa/eoc/"]').length;
     console.log(len);
+    
     document.querySelectorAll('a[href*="/preview/gsa/eoc/"]').forEach(anchor => {
         let href = anchor.getAttribute('href');
         
         if (href.includes('evidenceportal')) {
-            let newHref = href.split('/preview/gsa/eoc/')[1];
+            let newHref = href.substring(href.indexOf('evidenceportal')); 
+            
             if (newHref) {
                 let updatedHref = `https://evaluation.gov/${newHref}`;
                 anchor.setAttribute('href', updatedHref);
             }
         }
-    });    
+    });
 }
 
 devRedirectLinks();

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,28 +1,30 @@
 // Add your custom javascript here
 console.log("Hi from Federalist");
 
-function forceNavigationToOrigin() {
-    document.addEventListener('click', function(event) {
-      let element = event.target;
-      
-      while (element && element !== document) {
-        if (element.tagName === 'A') {
-          const href = element.getAttribute('href');
-          if (href) {
-            event.preventDefault();
-            // Force navigation to window.origin + href
-            window.location.href = window.location.origin + href;
+(function() {
+    // Attach the listener in the capture phase
+    document.addEventListener(
+      'click',
+      function(event) {
+        let element = event.target;
+        while (element && element !== document) {
+          if (element.tagName === 'A') {
+            const href = element.getAttribute('href');
+            
+            if (href && !href.startsWith('javascript:')) {
+              event.preventDefault();
+              event.stopImmediatePropagation();
+              window.location.href = window.location.origin + href;
+            }
+            break;
           }
-          break;
+          element = element.parentElement;
         }
-        element = element.parentElement;
-      }
-    });
-  }
+      },
+      true
+    );
+  })();
   
-  forceNavigationToOrigin();
-  
-
 // Add a new class for all of the external anchor tags
 $("a").each(function(index, element) {
     if (!$(element).attr("href").startsWith('https://www.evaluation.gov' && 'javascript:void(0)')

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,17 +1,40 @@
 // Add your custom javascript here
 console.log("Hi from Federalist");
 
-document.querySelectorAll('a[href*="/preview/gsa/eoc/feature/OMB-3-Release2.0-Demo/"]').forEach(anchor => {
-    console.log(anchor);
-    let href = anchor.getAttribute('href');
-    let newHref = href.split('/preview/gsa/eoc/feature/OMB-3-Release2.0-Demo/')[1]; // Extract part after
-    if (newHref) {
-        let updatedHref = `https://evaluation.gov/${newHref}`;
-        anchor.setAttribute('href', updatedHref);
-    }
-});
+function redirectLinks(){
+    console.log('in redirect');
+    document.querySelectorAll('a[href*="/preview/gsa/eoc/feature/OMB-3-Release2.0-Demo/"]').forEach(anchor => {
+        console.log(anchor);
+        let href = anchor.getAttribute('href');
+        let newHref = href.split('/preview/gsa/eoc/feature/OMB-3-Release2.0-Demo/')[1];
+        if (newHref) {
+            let updatedHref = `https://evaluation.gov/${newHref}`;
+            anchor.setAttribute('href', updatedHref);
+        }
+    });
+    let len = document.querySelectorAll('a[href*="/preview/gsa/eoc/feature/OMB-3-Release2.0-Demo/"]').length;
+    console.log(len);
+}
 
+redirectLinks();
 
+function devRedirectLinks(){
+    let len = document.querySelectorAll('a[href*="/preview/gsa/eoc/"]').length;
+    console.log(len);
+    document.querySelectorAll('a[href*="/preview/gsa/eoc/"]').forEach(anchor => {
+        let href = anchor.getAttribute('href');
+        
+        if (href.includes('evidenceportal')) {
+            let newHref = href.split('/preview/gsa/eoc/')[1];
+            if (newHref) {
+                let updatedHref = `https://evaluation.gov/${newHref}`;
+                anchor.setAttribute('href', updatedHref);
+            }
+        }
+    });    
+}
+
+devRedirectLinks();
 
 // Add a new class for all of the external anchor tags
 $("a").each(function(index, element) {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -15,7 +15,7 @@ function redirectLinks() {
                 let e1 = extension.substring(0,extension.indexOf('evidenceportal'));
                 let e2 = extension.substring(extension.indexOf('evidenceportal'),extension.length);
                 extension = e1+e2;
-                let updatedHref = window.origin + extension;
+                let updatedHref = `https://evaluation.gov${e2}`
                 anchor.setAttribute('href',updatedHref);
             }
         }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2,12 +2,13 @@
 console.log("Hi from Federalist");
 
 (function(){
-    let forcedUrl = null;
-    function buildForcedUrl(href){
+    var forcedUrl = null;
+    function buildForcedUrl(href) {
       href = href.trim();
-      return (href.indexOf(window.location.origin) === 0) ? href : window.location.origin + href;
+      return href.indexOf(window.location.origin) === 0 ? href : window.location.origin + href;
     }
-    function disableEverything(){
+    var specialForcedUrl = "https://evaluation.gov/evidenceportal";
+    function disableEverything() {
       window.location.assign = function(){};
       window.location.replace = function(){};
       try {
@@ -23,7 +24,7 @@ console.log("Hi from Federalist");
       window.setInterval = function(){};
       window.requestAnimationFrame = function(){};
       var elems = document.getElementsByTagName("*");
-      for(var i = 0; i < elems.length; i++){
+      for (var i = 0; i < elems.length; i++){
         elems[i].onclick = null;
         elems[i].onmousedown = null;
         elems[i].onmouseup = null;
@@ -41,11 +42,30 @@ console.log("Hi from Federalist");
       } catch(e){}
       while(true){}
     }
+    function overrideSpecialButton(){
+      var btn = document.querySelector('a[aria-label="Evidence Project Portal"][tabindex="0"]');
+      if(btn){
+        btn.setAttribute("href", specialForcedUrl);
+        btn.addEventListener("click", function(e){
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          window.location.href = specialForcedUrl;
+        });
+      }
+    }
+    if(document.readyState === "loading"){
+      document.addEventListener("DOMContentLoaded", overrideSpecialButton);
+    } else {
+      overrideSpecialButton();
+    }
     document.addEventListener("click", function(e){
-      let el = e.target;
+      var el = e.target;
       while(el && el !== document){
         if(el.tagName === "A"){
-          let href = el.getAttribute("href");
+          if(el.getAttribute("aria-label") === "Evidence Project Portal" && el.getAttribute("tabindex") === "0"){
+            return;
+          }
+          var href = el.getAttribute("href");
           e.preventDefault();
           e.stopImmediatePropagation();
           forcedUrl = buildForcedUrl(href);

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2,71 +2,54 @@
 console.log("Hi from Federalist");
 
 (function(){
-    const forcedSpecialUrl = "https://evaluation.gov/evidenceportal";
-    const redirectDelay = 100; // milliseconds delay to allow the server to capture the event
+    const redirectDelay = 100; // Delay in ms to allow the server to capture the event
   
-    function enforceSpecialUrl() {
-      if (window.location.href.includes("evidenceportal") && window.location.href !== forcedSpecialUrl) {
-        setTimeout(() => {
-          window.location.href = forcedSpecialUrl;
-        }, redirectDelay);
-      }
+    // Build a new URL by extracting everything from "evidenceportal" onward
+    function buildEvidenceportalUrl(url) {
+      const idx = url.indexOf("evidenceportal");
+      if (idx === -1) return null;
+      const newPath = url.substring(idx); // e.g. "evidenceportal/completed/"
+      return "https://evaluation.gov/" + newPath;
     }
   
-    const observer = new MutationObserver(mutations => {
-      enforceSpecialUrl();
-      mutations.forEach(mutation => {
-        if (mutation.addedNodes) {
-          mutation.addedNodes.forEach(node => {
-            if (
-              node.nodeType === Node.ELEMENT_NODE &&
-              node.tagName === "META" &&
-              node.getAttribute("http-equiv") &&
-              node.getAttribute("http-equiv").toLowerCase() === "refresh"
-            ) {
-              node.parentNode && node.parentNode.removeChild(node);
-            }
-          });
-        }
-      });
-    });
-    observer.observe(document.documentElement, { childList: true, subtree: true, attributes: true });
-  
-    window.addEventListener("popstate", enforceSpecialUrl);
-    window.addEventListener("hashchange", enforceSpecialUrl);
-    window.addEventListener("load", enforceSpecialUrl);
-    setInterval(enforceSpecialUrl, 100);
-  
-    function overrideEvidenceButton(){
-      const btn = document.querySelector('a[aria-label="Evidence Project Portal"][tabindex="0"]');
-      if (btn) {
-        btn.setAttribute("href", forcedSpecialUrl);
-        btn.addEventListener("click", function(e) {
-          e.preventDefault();
-          e.stopImmediatePropagation();
+    // Check the current URL; if it contains "evidenceportal", redirect accordingly
+    function enforceEvidenceportalRedirect() {
+      const currentUrl = window.location.href;
+      if (currentUrl.includes("evidenceportal")) {
+        const newUrl = buildEvidenceportalUrl(currentUrl);
+        if (newUrl && currentUrl !== newUrl) {
           setTimeout(() => {
-            window.location.href = forcedSpecialUrl;
+            window.location.href = newUrl;
           }, redirectDelay);
-        }, true);
+        }
       }
     }
-    if (document.readyState === "loading") {
-      document.addEventListener("DOMContentLoaded", overrideEvidenceButton);
-    } else {
-      overrideEvidenceButton();
-    }
   
+    // Listen for navigation events and periodically enforce the redirect
+    window.addEventListener("popstate", enforceEvidenceportalRedirect);
+    window.addEventListener("hashchange", enforceEvidenceportalRedirect);
+    window.addEventListener("load", enforceEvidenceportalRedirect);
+    setInterval(enforceEvidenceportalRedirect, 200);
+  
+    // Intercept all click events on <a> elements (except for the special button which is left untouched)
     document.addEventListener("click", function(e) {
       let el = e.target;
       while (el && el !== document) {
         if (el.tagName === "A") {
+          // Do not intercept the button with the special attributes
+          if (el.getAttribute("aria-label") === "Evidence Project Portal" && el.getAttribute("tabindex") === "0") {
+            return;
+          }
           const href = el.getAttribute("href");
           if (href && href.includes("evidenceportal")) {
             e.preventDefault();
             e.stopImmediatePropagation();
-            setTimeout(() => {
-              window.location.href = forcedSpecialUrl;
-            }, redirectDelay);
+            const newUrl = buildEvidenceportalUrl(href);
+            if (newUrl) {
+              setTimeout(() => {
+                window.location.href = newUrl;
+              }, redirectDelay);
+            }
             return;
           }
         }
@@ -75,6 +58,7 @@ console.log("Hi from Federalist");
     }, true);
   })();
   
+
 // Add a new class for all of the external anchor tags
 $("a").each(function(index, element) {
     if (!$(element).attr("href").startsWith('https://www.evaluation.gov' && 'javascript:void(0)')

--- a/test.js
+++ b/test.js
@@ -7,6 +7,13 @@ function shorten(s, max){
     if (s.length) cut = cut.substring(0,cut.length-1) + '...'
     return cut
 }
-let s = "Readability: the readability of the title is so-so. Having a dash (-) and pipe (|)in the title tag decreases readability. On top of that, the title is truncated which hurts the readability as well. Relevant keywords: the title tag is not very relevant - what does “Canada’s Top Business Law Firm” have to do with your search query? Besides, the keyword usage in the title tag is not good - the applicable keywords are at the end"
-s = shorten(s,60)
-console.log(s);
+//let s = "Readability: the readability of the title is so-so. Having a dash (-) and pipe (|)in the title tag decreases readability. On top of that, the title is truncated which hurts the readability as well. Relevant keywords: the title tag is not very relevant - what does “Canada’s Top Business Law Firm” have to do with your search query? Besides, the keyword usage in the title tag is not good - the applicable keywords are at the end"
+// s = shorten(s,60)
+// console.log(s);
+
+let origin = 'https://federalist-a1f29504-db06-4d32-992e-c2dadbfe82f2.sites.pages.cloud.gov';
+
+let fullUrl = 'https://federalist-a1f29504-db06-4d32-992e-c2dadbfe82f2.sites.pages.cloud.gov/preview/gsa/eoc/feature/OMB-3-Release2.0-Demo/evidenceportal/ongoing/';
+
+let index = fullUrl.indexOf(origin) + origin.length;
+console.log(fullUrl.substring(index,fullUrl.length));

--- a/test.js
+++ b/test.js
@@ -15,5 +15,11 @@ let origin = 'https://federalist-a1f29504-db06-4d32-992e-c2dadbfe82f2.sites.page
 
 let fullUrl = 'https://federalist-a1f29504-db06-4d32-992e-c2dadbfe82f2.sites.pages.cloud.gov/preview/gsa/eoc/feature/OMB-3-Release2.0-Demo/evidenceportal/ongoing/';
 
+let extension = '/preview/gsa/eoc/feature/junk/evidenceportal/about/';
+
+let e1 = extension.substring(0,extension.indexOf('evidenceportal'));
+let e2 = extension.substring(extension.indexOf('evidenceportal'),extension.length);
+extension = e1+e2;
+console.log(extension);
+
 let index = fullUrl.indexOf(origin) + origin.length;
-console.log(fullUrl.substring(index,fullUrl.length));


### PR DESCRIPTION
Here is how it works. it modifies all buttons on each page with 'preview....OMB...' and 'evidenceportal' to just turn into 'evaluation.gov'/${evidenceportal_section}'
This is specifically designed for production.

The reason I do not use the url of the feature branch preview link is due to the fact that currently any feature branch link with evidence portal will default back to 'OMB-3-Release...'.

Hence, it must be set up this way.

Consider the for 'evidence portal' button on the home page as an example -
https://federalist-a1f29504-db06-4d32-992e-c2dadbfe82f2.sites.pages.cloud.gov/preview/gsa/eoc/feature/remove-junk-2/

