### PR TITLE
remove linkedin

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -55,9 +55,9 @@
                                         <div class="grid-col-auto padding-top-105">
                                             <a id="footerMailTo" href="mailto:evidence@omb.eop.gov" target="_blank" title="Mail"><i class="fa fa-envelope img-align" aria-hidden="true" style="padding-top:6px"></i></a>
                                         </div>
-                                        <div class="grid-col-auto padding-top-105 padding-left-105">
+                                        <!-- <div class="grid-col-auto padding-top-105 padding-left-105">
                                             <a id="footerLinkedIn" href="https://www.linkedin.com/company/evaluation-gov/" target="_blank" title="LinkedIn"><img src="{{site.baseurl}}/assets/images/linkedin-icon.png" alt="LinkedIn Icon" class="img-align" /></a>
-                                        </div>
+                                        </div> -->
                                     </div>
                                 </div>
                             </section>


### PR DESCRIPTION
Approved

[Preview](https://federalist-a1f29504-db06-4d32-992e-c2dadbfe82f2.sites.pages.cloud.gov/preview/gsa/eoc/feature/RITM1298347/)

We need to remove references to the LinkedIn account on Evaluation.gov; specifically the icon that currently links out (see attached screenshot).