### PR TITLE
Potential fix for code scanning alert no. 28: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/slick.js
+++ b/assets/js/slick.js
@@ -29,6 +29,15 @@
     'use strict';
     var Slick = window.Slick || {};
 
+    function isValidUrl(url) {
+        try {
+            new URL(url);
+            return true;
+        } catch (e) {
+            return false;
+        }
+    }
+
     Slick = (function () {
 
         var instanceUid = 0;
@@ -1695,7 +1704,18 @@
 
             };
 
-            imageToLoad.src = imageSource;
+            if (isValidUrl(imageSource)) {
+                imageToLoad.src = imageSource;
+            } else {
+                image
+                    .removeAttr('data-lazy')
+                    .removeClass('slick-loading')
+                    .addClass('slick-lazyload-error');
+
+                _.$slider.trigger('lazyLoadError', [_, image, imageSource]);
+
+                _.progressiveLazyLoad();
+            }
 
         } else {
 


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/eoc/security/code-scanning/28](https://github.com/GSA/eoc/security/code-scanning/28)

To fix the problem, we need to ensure that the value of the `data-lazy` attribute is properly sanitized before it is used to set the `src` attribute of the image element. This can be achieved by using a function to validate and sanitize the URL.

The best way to fix the problem without changing existing functionality is to introduce a function that checks if the URL is valid and safe. We can use the `URL` constructor to parse the URL and ensure it is a valid URL. If the URL is not valid, we can skip setting the `src` attribute.

We will make the following changes in the file `assets/js/slick.js`:
1. Add a function `isValidUrl` to validate the URL.
2. Use the `isValidUrl` function to check the `imageSource` before setting the `src` attribute of `imageToLoad`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
