### PR TITLE
Potential fix for code scanning alert no. 26: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/slick.js
+++ b/assets/js/slick.js
@@ -1489,7 +1489,17 @@
 
                 };
 
-                imageToLoad.src = imageSource;
+                try {
+                    var parsedURL = new URL(imageSource, window.location.origin);
+                    imageToLoad.src = parsedURL.href;
+                } catch (e) {
+                    console.warn('Invalid URL for lazy-loaded image:', imageSource);
+                    image
+                        .removeAttr('data-lazy')
+                        .removeClass('slick-loading')
+                        .addClass('slick-lazyload-error');
+                    _.$slider.trigger('lazyLoadError', [_, image, imageSource]);
+                }
 
             });
 


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/eoc/security/code-scanning/26](https://github.com/GSA/eoc/security/code-scanning/26)

To mitigate this vulnerability, the `imageSource` value should be validated or sanitized before it is assigned to the `src` attribute of the `img` element. A simple approach is to ensure that `imageSource` points to a valid and safe URL. This can be achieved by using JavaScript's URL constructor to parse and validate the URL. If the URL is invalid or does not point to an allowed domain, the code should not proceed to load the image.

The fix involves modifying the logic around line 1492 to include a validation step for `imageSource`. If the value is determined to be unsafe or invalid, the script should skip loading the image, log a warning, or handle the error gracefully.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
