### PR TITLE
Potential fix for code scanning alert no. 25: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/slick.js
+++ b/assets/js/slick.js
@@ -14,7 +14,7 @@
  Issues: http://github.com/kenwheeler/slick/issues
 
  */
-/* global window, document, define, jQuery, setInterval, clearInterval */
+/* global window, document, define, jQuery, setInterval, clearInterval, DOMPurify */
 (function (factory) {
     'use strict';
     if (typeof define === 'function' && define.amd) {
@@ -1460,6 +1460,7 @@
 
                 var image = $(this),
                     imageSource = $(this).attr('data-lazy'),
+                    sanitizedImageSource = DOMPurify.sanitize(imageSource),
                     imageToLoad = document.createElement('img');
 
                 imageToLoad.onload = function () {
@@ -1467,7 +1468,7 @@
                     image
                         .animate({ opacity: 0 }, 100, function () {
                             image
-                                .attr('src', imageSource)
+                                .attr('src', sanitizedImageSource)
                                 .animate({ opacity: 1 }, 200, function () {
                                     image
                                         .removeAttr('data-lazy')

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "@uswds/uswds": "3.8.1",
     "js-yaml": "^4.1.0",
-    "slugify": "^1.6.6"
+    "slugify": "^1.6.6",
+    "dompurify": "^3.2.6"
   },
   "devDependencies": {
     "rimraf": "^3.0.2"


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/eoc/security/code-scanning/25](https://github.com/GSA/eoc/security/code-scanning/25)

To fix the issue, the `data-lazy` attribute value should be sanitized or validated to ensure it is safe before being used as the `src` attribute of an image element. A robust solution involves escaping meta-characters or using a library designed for sanitizing URLs. Additionally, the `URL` constructor can be retained for syntactic validation, but further checks should be added to ensure the URL is safe.

The best approach is to use a well-known library like `DOMPurify` to sanitize the `data-lazy` attribute value before assigning it to the `src` attribute. This ensures that any malicious content is removed, preventing XSS attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
