### PR TITLE
Potential fix for code scanning alert no. 28: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/slick.js
+++ b/assets/js/slick.js
@@ -1659,7 +1659,7 @@
         if ($imgsToLoad.length) {
 
             image = $imgsToLoad.first();
-            imageSource = image.attr('data-lazy');
+            imageSource = DOMPurify.sanitize(image.attr('data-lazy'));
             imageToLoad = document.createElement('img');
 
             imageToLoad.onload = function () {


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/eoc/security/code-scanning/28](https://github.com/GSA/eoc/security/code-scanning/28)

To fix the issue, we need to sanitize the `data-lazy` attribute value before using it as the `src` attribute of the `img` element. A well-known library like `DOMPurify` can be used to ensure that the value is safe. Alternatively, we can validate the value to ensure it is a valid URL and does not contain any potentially harmful content.

The best approach is to use `DOMPurify` to sanitize the `imageSource` value. This ensures that any malicious content is removed before assigning it to the `src` attribute. The fix involves:
1. Importing or ensuring `DOMPurify` is available in the environment.
2. Sanitizing the `imageSource` value using `DOMPurify.sanitize()` before assigning it to `imageToLoad.src`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
